### PR TITLE
Replace LlamaKit with Result+Box

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "LlamaKit/LlamaKit" == 0.6.0
+github "antitypical/Result" ~> 0.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,2 @@
-github "LlamaKit/LlamaKit" "v0.6.0"
+github "robrix/Box" "1.2.2"
+github "antitypical/Result" "0.4.3"

--- a/Common/Core.swift
+++ b/Common/Core.swift
@@ -7,7 +7,7 @@
 //
 
 import Foundation
-import LlamaKit
+import Result
 
 /*
 Implements the the Semantic Versioning 2.0.0 spec:
@@ -309,7 +309,7 @@ public func <(lhs:Version.PreReleaseInfo, rhs:Version.PreReleaseInfo) -> Bool {
 
 public func parseVersion(versionStrng:String) -> Result<Version, String> {
     if versionStrng.isEmpty {
-        return failure("Empty string is not a valid version.")
+        return .failure("Empty string is not a valid version.")
     }
     
     let scanner = NSScanner(string: versionStrng)
@@ -317,7 +317,7 @@ public func parseVersion(versionStrng:String) -> Result<Version, String> {
     let success = scanner.scanUpToCharactersFromSet(NSCharacterSet(charactersInString: "-+"), intoString:&normalVersionStringOptional)
     
     if (!success) {
-        return failure("Unable to get main version from passed version string: \(versionStrng)")
+        return .failure("Unable to get main version from passed version string: \(versionStrng)")
     }
     
     /* We now know that mainResultString exists. */
@@ -325,7 +325,7 @@ public func parseVersion(versionStrng:String) -> Result<Version, String> {
         
         if scanner.atEnd {
             let version = Version(major: normalVersionComponents[0], minor: normalVersionComponents[1], patch: normalVersionComponents[2], preRelease: nil)
-            return .Success(Box(version))
+            return .success(version)
         }
         
         /*
@@ -340,7 +340,7 @@ public func parseVersion(versionStrng:String) -> Result<Version, String> {
             /* We are not quite at end end. Whatever remains is by definition metadata. */
             let metaData = versionStrng[advance(versionStrng.startIndex,scanner.scanLocation + 1)..<versionStrng.endIndex]
             return parseMetadata(metaData).flatMap { mdata in
-                return .Success(Box(Version(major: normalVersionComponents[0], minor: normalVersionComponents[1], patch: normalVersionComponents[2], preRelease:nil, metadata: mdata)))
+                return .success(Version(major: normalVersionComponents[0], minor: normalVersionComponents[1], patch: normalVersionComponents[2], preRelease:nil, metadata: mdata))
             }
         }
         
@@ -355,19 +355,19 @@ public func parseVersion(versionStrng:String) -> Result<Version, String> {
         var preReleaseInfo:NSString? = nil
         let success = scanner.scanUpToCharactersFromSet(NSCharacterSet(charactersInString:"+"), intoString: &preReleaseInfo)
         if (!success) {
-            return failure("Unable to get pre-release info for passed string: \(versionStrng)")
+            return .failure("Unable to get pre-release info for passed string: \(versionStrng)")
         }
         
         /* We have a pre-release string. Parse it. */
         return parsePreReleaseInfo(preReleaseInfo! as String).flatMap { parsedInfo in
             if scanner.atEnd {
-                return Result.Success(Box(Version(major: normalVersionComponents[0], minor: normalVersionComponents[1], patch: normalVersionComponents[2], preRelease:parsedInfo)))
+                return .success(Version(major: normalVersionComponents[0], minor: normalVersionComponents[1], patch: normalVersionComponents[2], preRelease:parsedInfo))
             }
             
             /* We are not quite at end end. Whatever remains is by definition metadata. */
             let metaData = versionStrng[advance(versionStrng.startIndex,scanner.scanLocation + 1)..<versionStrng.endIndex]
             return parseMetadata(metaData).flatMap { mdata in
-                return .Success(Box(Version(major: normalVersionComponents[0], minor: normalVersionComponents[1], patch: normalVersionComponents[2], preRelease: parsedInfo, metadata: mdata)))
+                return .success(Version(major: normalVersionComponents[0], minor: normalVersionComponents[1], patch: normalVersionComponents[2], preRelease: parsedInfo, metadata: mdata))
             }
         }
         
@@ -394,15 +394,15 @@ func parseNormalVersionString(string:String) -> Result<[Int], String> {
         if let num = intFromString(str) {
             results += [num]
         } else {
-            return failure("String \"\(str)\" could not be parsed as a number in normal version: \"\(string)")
+            return .failure("String \"\(str)\" could not be parsed as a number in normal version: \"\(string)")
         }
     }
     
     if results.count != 3 {
-        return failure("Normal version must be in M.m.p format, where each of M, m, and p are integers. Passed normal version was: \(string)")
+        return .failure("Normal version must be in M.m.p format, where each of M, m, and p are integers. Passed normal version was: \(string)")
     }
     
-    return success(results)
+    return .success(results)
 }
 
 func parsePreReleaseInfo(info:String) -> Result<[String], String> {
@@ -411,11 +411,11 @@ func parsePreReleaseInfo(info:String) -> Result<[String], String> {
     
     for str in components {
         if !(str =~ /"^[0-9a-zA-Z\\-]+$") {
-            return failure("A component of pre-release info string \"\(info)\" is not in the required character set: [0-9a-zA-S\\-]")
+            return .failure("A component of pre-release info string \"\(info)\" is not in the required character set: [0-9a-zA-S\\-]")
         }
     }
     
-    return success(components)
+    return .success(components)
 }
 
 func parseMetadata(metadata:String) -> Result<String, String> {
@@ -423,11 +423,11 @@ func parseMetadata(metadata:String) -> Result<String, String> {
     let components = metadata.componentsSeparatedByString(".")
     for str in components {
         if !(str =~ /"^[0-9a-zA-Z\\-]+$") {
-            return failure("A component of metadata string \"\(metadata)\" is not in the required character set: [0-9a-zA-Z\\-]")
+            return .failure("A component of metadata string \"\(metadata)\" is not in the required character set: [0-9a-zA-Z\\-]")
         }
     }
     
-    return success(metadata)
+    return .success(metadata)
 }
 
 /**

--- a/CommonTests/CoreTests.swift
+++ b/CommonTests/CoreTests.swift
@@ -7,7 +7,8 @@
 //
 
 import XCTest
-import LlamaKit
+import Box
+import Result
 import SemverKit
 
 class CoreTests: XCTestCase {
@@ -58,7 +59,7 @@ class CoreTests: XCTestCase {
         var str = "2.1.0"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
+            let version = box.value
             XCTAssertEqual(version.major, 2, "Incorrect major version for version string \"\(str)\".")
             XCTAssertEqual(version.minor, 1, "Incorrect minor version for version string \"\(str)\".")
             XCTAssertEqual(version.patch, 0, "Incorrect patch version for version string \"\(str)\".")
@@ -73,7 +74,7 @@ class CoreTests: XCTestCase {
         str = "2900.1023456.23475323"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
+            let version = box.value
             XCTAssertEqual(version.major, 2900, "Incorrect major version for version string \"\(str)\".")
             XCTAssertEqual(version.minor, 1023456, "Incorrect minor version for version string \"\(str)\".")
             XCTAssertEqual(version.patch, 23475323, "Incorrect patch version for version string \"\(str)\".")
@@ -88,7 +89,7 @@ class CoreTests: XCTestCase {
         str = "1.0.0-alpha"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
+            let version = box.value
             XCTAssertEqual(version.major, 1, "Incorrect major version for version string \"\(str)\".")
             XCTAssertEqual(version.minor, 0, "Incorrect minor version for version string \"\(str)\".")
             XCTAssertEqual(version.patch, 0, "Incorrect patch version for version string \"\(str)\".")
@@ -103,7 +104,7 @@ class CoreTests: XCTestCase {
         str = "1.0.0-alpha.1"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
+            let version = box.value
             XCTAssertEqual(version.major, 1, "Incorrect major version for version string \"\(str)\".")
             XCTAssertEqual(version.minor, 0, "Incorrect minor version for version string \"\(str)\".")
             XCTAssertEqual(version.patch, 0, "Incorrect patch version for version string \"\(str)\".")
@@ -117,7 +118,7 @@ class CoreTests: XCTestCase {
         str = "1.0.0-0.3.7"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
+            let version = box.value
             XCTAssertEqual(version.major, 1, "Incorrect major version for version string \"\(str)\".")
             XCTAssertEqual(version.minor, 0, "Incorrect minor version for version string \"\(str)\".")
             XCTAssertEqual(version.patch, 0, "Incorrect patch version for version string \"\(str)\".")
@@ -131,7 +132,7 @@ class CoreTests: XCTestCase {
         str = "1.0.0-x.7.z.92"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
+            let version = box.value
             XCTAssertEqual(version.major, 1, "Incorrect major version for version string \"\(str)\".")
             XCTAssertEqual(version.minor, 0, "Incorrect minor version for version string \"\(str)\".")
             XCTAssertEqual(version.patch, 0, "Incorrect patch version for version string \"\(str)\".")
@@ -146,7 +147,7 @@ class CoreTests: XCTestCase {
         str = "1.0.0-x.7.secret-alpha.92"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
+            let version = box.value
             XCTAssertEqual(version.major, 1, "Incorrect major version for version string \"\(str)\".")
             XCTAssertEqual(version.minor, 0, "Incorrect minor version for version string \"\(str)\".")
             XCTAssertEqual(version.patch, 0, "Incorrect patch version for version string \"\(str)\".")
@@ -160,7 +161,7 @@ class CoreTests: XCTestCase {
         str = "1.0.0-x.7.secret-alpha.92"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
+            let version = box.value
             XCTAssertEqual(version.major, 1, "Incorrect major version for version string \"\(str)\".")
             XCTAssertEqual(version.minor, 0, "Incorrect minor version for version string \"\(str)\".")
             XCTAssertEqual(version.patch, 0, "Incorrect patch version for version string \"\(str)\".")
@@ -174,7 +175,7 @@ class CoreTests: XCTestCase {
         str = "1.0.0-alpha.-1"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
+            let version = box.value
             XCTAssertEqual(version.major, 1, "Incorrect major version for version string \"\(str)\".")
             XCTAssertEqual(version.minor, 0, "Incorrect minor version for version string \"\(str)\".")
             XCTAssertEqual(version.patch, 0, "Incorrect patch version for version string \"\(str)\".")
@@ -188,7 +189,7 @@ class CoreTests: XCTestCase {
         str = "1.0.0--alpha.1"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
+            let version = box.value
             XCTAssertEqual(version.major, 1, "Incorrect major version for version string \"\(str)\".")
             XCTAssertEqual(version.minor, 0, "Incorrect minor version for version string \"\(str)\".")
             XCTAssertEqual(version.patch, 0, "Incorrect patch version for version string \"\(str)\".")
@@ -204,7 +205,7 @@ class CoreTests: XCTestCase {
         str = "1.0.0+x.7.ver92"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
+            let version = box.value
             XCTAssertEqual(version.major, 1, "Incorrect major version for version string \"\(str)\".")
             XCTAssertEqual(version.minor, 0, "Incorrect minor version for version string \"\(str)\".")
             XCTAssertEqual(version.patch, 0, "Incorrect patch version for version string \"\(str)\".")
@@ -219,7 +220,7 @@ class CoreTests: XCTestCase {
         str = "1.0.0-alpha.13+x.7.ver92"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
+            let version = box.value
             XCTAssertEqual(version.major, 1, "Incorrect major version for version string \"\(str)\".")
             XCTAssertEqual(version.minor, 0, "Incorrect minor version for version string \"\(str)\".")
             XCTAssertEqual(version.patch, 0, "Incorrect patch version for version string \"\(str)\".")
@@ -235,7 +236,7 @@ class CoreTests: XCTestCase {
         str = "1.0.0-alpha.13+-x.7.ver92"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
+            let version = box.value
             XCTAssertEqual(version.major, 1, "Incorrect major version for version string \"\(str)\".")
             XCTAssertEqual(version.minor, 0, "Incorrect minor version for version string \"\(str)\".")
             XCTAssertEqual(version.patch, 0, "Incorrect patch version for version string \"\(str)\".")
@@ -375,7 +376,7 @@ class CoreTests: XCTestCase {
 func forceUnwrap<T, E>(result:Result<T, E>) -> T {
     switch result {
     case .Success(let box):
-        return box.unbox
+        return box.value
     case .Failure(let err):
         println("Failed to unwrap \(result)")
         abort()

--- a/CommonTests/IncrementTests.swift
+++ b/CommonTests/IncrementTests.swift
@@ -9,6 +9,7 @@
 import Foundation
 import XCTest
 import SemverKit
+import Box
 
 class IncrementTests : XCTestCase {
     func testNextMajorVersion() {
@@ -23,8 +24,8 @@ class IncrementTests : XCTestCase {
         for str in strs {
             switch parseVersion(str) {
             case .Success(let box):
-                let version = box.unbox
-                let nextVersion = box.unbox.nextMajorVersion()
+                let version = box.value
+                let nextVersion = box.value.nextMajorVersion()
                 let finalErrStr = "for next major version of \"\(str)\"."
                 XCTAssertEqual(nextVersion.major, version.major + 1, "Incorrect major version \(finalErrStr)")
                 XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -49,8 +50,8 @@ class IncrementTests : XCTestCase {
         for str in strs {
             switch parseVersion(str) {
             case .Success(let box):
-                let version = box.unbox
-                let nextVersion = box.unbox.nextMinorVersion()
+                let version = box.value
+                let nextVersion = box.value.nextMinorVersion()
                 let finalErrStr = "for next minor version of \"\(str)\"."
                 XCTAssertEqual(nextVersion.major, version.major, "Incorrect major version \(finalErrStr)")
                 XCTAssertEqual(nextVersion.minor, version.minor + 1, "Incorrect minor version \(finalErrStr)")
@@ -75,8 +76,8 @@ class IncrementTests : XCTestCase {
         for str in strs {
             switch parseVersion(str) {
             case .Success(let box):
-                let version = box.unbox
-                let nextVersion = box.unbox.nextPatchVersion()
+                let version = box.value
+                let nextVersion = box.value.nextPatchVersion()
                 let finalErrStr = "for next patch version of \"\(str)\"."
                 XCTAssertEqual(nextVersion.major, version.major, "Incorrect major version \(finalErrStr)")
                 XCTAssertEqual(nextVersion.minor, version.minor, "Incorrect minor version \(finalErrStr)")
@@ -93,8 +94,8 @@ class IncrementTests : XCTestCase {
         var str = "2.0.2"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 3, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -108,8 +109,8 @@ class IncrementTests : XCTestCase {
         str = "2.2.0"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 3, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -123,8 +124,8 @@ class IncrementTests : XCTestCase {
         str = "2.1.0-alpha.4"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 3, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -138,8 +139,8 @@ class IncrementTests : XCTestCase {
         str = "2.0.8-alpha.4"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 3, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -153,8 +154,8 @@ class IncrementTests : XCTestCase {
         str = "2.0.0-alpha.4"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -168,8 +169,8 @@ class IncrementTests : XCTestCase {
         str = "2.0.0-alpha"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -183,8 +184,8 @@ class IncrementTests : XCTestCase {
         str = "2.0.0-45423"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -198,8 +199,8 @@ class IncrementTests : XCTestCase {
         str = "2.0.0-tom"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 3, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -215,8 +216,8 @@ class IncrementTests : XCTestCase {
         var str = "2.0.2"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMinorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMinorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 1, "Incorrect minor version \(finalErrStr)")
@@ -230,8 +231,8 @@ class IncrementTests : XCTestCase {
         str = "2.0.2-alpha.0"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMinorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMinorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 1, "Incorrect minor version \(finalErrStr)")
@@ -245,8 +246,8 @@ class IncrementTests : XCTestCase {
         str = "2.0.2-alpha.5"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMinorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMinorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 1, "Incorrect minor version \(finalErrStr)")
@@ -260,8 +261,8 @@ class IncrementTests : XCTestCase {
         str = "2.1.0-alpha.5"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMinorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMinorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 1, "Incorrect minor version \(finalErrStr)")
@@ -275,8 +276,8 @@ class IncrementTests : XCTestCase {
         str = "2.1.0-beta.5"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMinorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMinorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 2, "Incorrect minor version \(finalErrStr)")
@@ -290,8 +291,8 @@ class IncrementTests : XCTestCase {
         str = "2.0.0"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMinorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMinorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 1, "Incorrect minor version \(finalErrStr)")
@@ -305,8 +306,8 @@ class IncrementTests : XCTestCase {
         str = "2.0.0-12"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMinorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMinorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -320,8 +321,8 @@ class IncrementTests : XCTestCase {
         str = "2.0.0-alpha.k"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMinorAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMinorAlphaVersion()
             let finalErrStr = "for next minor alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 1, "Incorrect minor version \(finalErrStr)")
@@ -337,8 +338,8 @@ class IncrementTests : XCTestCase {
         var str = "5.0.3"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextPatchAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextPatchAlphaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 5, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -352,8 +353,8 @@ class IncrementTests : XCTestCase {
         str = "5.0.3-alpha.0"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextPatchAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextPatchAlphaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 5, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -367,8 +368,8 @@ class IncrementTests : XCTestCase {
         str = "5.0.3-beta.7"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextPatchAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextPatchAlphaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 5, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -382,8 +383,8 @@ class IncrementTests : XCTestCase {
         str = "5.0.3-alpha"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextPatchAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextPatchAlphaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 5, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -397,8 +398,8 @@ class IncrementTests : XCTestCase {
         str = "5.0.3-alpha.m"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextPatchAlphaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextPatchAlphaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 5, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -414,8 +415,8 @@ class IncrementTests : XCTestCase {
         var str = "5.0.3"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 6, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -429,8 +430,8 @@ class IncrementTests : XCTestCase {
         str = "5.2.0"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 6, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -444,8 +445,8 @@ class IncrementTests : XCTestCase {
         str = "5.2.0-alpha.0"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 6, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -459,8 +460,8 @@ class IncrementTests : XCTestCase {
         str = "5.2.0-beta.0"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 6, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -474,8 +475,8 @@ class IncrementTests : XCTestCase {
         str = "5.0.0-beta.2"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 5, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -489,8 +490,8 @@ class IncrementTests : XCTestCase {
         str = "5.0.0-beta.2+metadata"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 5, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -504,8 +505,8 @@ class IncrementTests : XCTestCase {
         str = "5.0.0-tim"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 6, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -519,8 +520,8 @@ class IncrementTests : XCTestCase {
         str = "5.0.0-123"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMajorBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMajorBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 5, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -536,8 +537,8 @@ class IncrementTests : XCTestCase {
         var str = "5.1.0"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMinorBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMinorBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 5, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 2, "Incorrect minor version \(finalErrStr)")
@@ -551,8 +552,8 @@ class IncrementTests : XCTestCase {
         str = "5.1.0-alpha.2"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMinorBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMinorBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 5, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 1, "Incorrect minor version \(finalErrStr)")
@@ -566,8 +567,8 @@ class IncrementTests : XCTestCase {
         str = "2.1.0-beta.2"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMinorBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMinorBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 1, "Incorrect minor version \(finalErrStr)")
@@ -581,8 +582,8 @@ class IncrementTests : XCTestCase {
         str = "2.1.2-beta.2"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMinorBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMinorBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 2, "Incorrect minor version \(finalErrStr)")
@@ -596,8 +597,8 @@ class IncrementTests : XCTestCase {
         str = "2.1.0-done"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMinorBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMinorBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 2, "Incorrect minor version \(finalErrStr)")
@@ -611,8 +612,8 @@ class IncrementTests : XCTestCase {
         str = "2.1.0-23"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMinorBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMinorBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 1, "Incorrect minor version \(finalErrStr)")
@@ -626,8 +627,8 @@ class IncrementTests : XCTestCase {
         str = "2.1.0-beta"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextMinorBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextMinorBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 1, "Incorrect minor version \(finalErrStr)")
@@ -643,8 +644,8 @@ class IncrementTests : XCTestCase {
         var str = "2.1.0-beta"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextPatchBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextPatchBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 1, "Incorrect minor version \(finalErrStr)")
@@ -658,8 +659,8 @@ class IncrementTests : XCTestCase {
         str = "2.1.0"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextPatchBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextPatchBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 1, "Incorrect minor version \(finalErrStr)")
@@ -673,8 +674,8 @@ class IncrementTests : XCTestCase {
         str = "2.1.0-beta.1"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextPatchBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextPatchBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 1, "Incorrect minor version \(finalErrStr)")
@@ -688,8 +689,8 @@ class IncrementTests : XCTestCase {
         str = "2.0.0"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextPatchBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextPatchBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -703,8 +704,8 @@ class IncrementTests : XCTestCase {
         str = "2.0.0-700"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextPatchBetaVersion()
+            let version = box.value
+            let nextVersion = box.value.nextPatchBetaVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -722,8 +723,8 @@ class IncrementTests : XCTestCase {
         var str = "2.0.0"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextStableVersion()
+            let version = box.value
+            let nextVersion = box.value.nextStableVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -737,8 +738,8 @@ class IncrementTests : XCTestCase {
         str = "3.1.0"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextStableVersion()
+            let version = box.value
+            let nextVersion = box.value.nextStableVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 3, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 1, "Incorrect minor version \(finalErrStr)")
@@ -752,8 +753,8 @@ class IncrementTests : XCTestCase {
         str = "19.7.2"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextStableVersion()
+            let version = box.value
+            let nextVersion = box.value.nextStableVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 19, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 7, "Incorrect minor version \(finalErrStr)")
@@ -769,8 +770,8 @@ class IncrementTests : XCTestCase {
         str = "2.0.0-alpha.1"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextStableVersion()
+            let version = box.value
+            let nextVersion = box.value.nextStableVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 2, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 0, "Incorrect minor version \(finalErrStr)")
@@ -784,8 +785,8 @@ class IncrementTests : XCTestCase {
         str = "3.1.0-beta.23"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextStableVersion()
+            let version = box.value
+            let nextVersion = box.value.nextStableVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 3, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 1, "Incorrect minor version \(finalErrStr)")
@@ -799,8 +800,8 @@ class IncrementTests : XCTestCase {
         str = "19.7.2-test"
         switch parseVersion(str) {
         case .Success(let box):
-            let version = box.unbox
-            let nextVersion = box.unbox.nextStableVersion()
+            let version = box.value
+            let nextVersion = box.value.nextStableVersion()
             let finalErrStr = "for next patch alpha version of \"\(str)\"."
             XCTAssertEqual(nextVersion.major, 19, "Incorrect major version \(finalErrStr)")
             XCTAssertEqual(nextVersion.minor, 7, "Incorrect minor version \(finalErrStr)")

--- a/SemverKit.xcodeproj/project.pbxproj
+++ b/SemverKit.xcodeproj/project.pbxproj
@@ -21,9 +21,14 @@
 		7D44C4B119C8C82E0063E49F /* Regex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D44C4AA19C8C82E0063E49F /* Regex.swift */; };
 		7D50B46019D35F6200743806 /* CommandLineOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D50B45F19D35F6200743806 /* CommandLineOptions.swift */; };
 		7D50B46219D35F9E00743806 /* CommandLineOptionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D50B46119D35F9E00743806 /* CommandLineOptionsTests.swift */; };
-		7DABE40A1AC7706600D0017B /* LlamaKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DABE4091AC7706600D0017B /* LlamaKit.framework */; };
-		7DE0978D1AC756720099D99C /* LlamaKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7DE0978B1AC7546E0099D99C /* LlamaKit.framework */; };
-		7DE0978F1AC757AE0099D99C /* LlamaKit.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = 7DE0978B1AC7546E0099D99C /* LlamaKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		D82399581B166E5F0096E95C /* Box.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D82399561B166E5F0096E95C /* Box.framework */; };
+		D82399591B166E5F0096E95C /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D82399571B166E5F0096E95C /* Result.framework */; };
+		D823995C1B166E7D0096E95C /* Box.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D823995A1B166E7D0096E95C /* Box.framework */; };
+		D823995D1B166E7D0096E95C /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D823995B1B166E7D0096E95C /* Result.framework */; };
+		D82399601B166EF00096E95C /* Box.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D82399561B166E5F0096E95C /* Box.framework */; };
+		D82399611B166EF00096E95C /* Result.framework in Copy Frameworks */ = {isa = PBXBuildFile; fileRef = D82399571B166E5F0096E95C /* Result.framework */; };
+		D82399631B166F0A0096E95C /* Box.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = D823995A1B166E7D0096E95C /* Box.framework */; };
+		D82399641B166F0A0096E95C /* Result.framework in Copy Files */ = {isa = PBXBuildFile; fileRef = D823995B1B166E7D0096E95C /* Result.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -41,9 +46,10 @@
 			isa = PBXCopyFilesBuildPhase;
 			buildActionMask = 2147483647;
 			dstPath = "";
-			dstSubfolderSpec = 10;
+			dstSubfolderSpec = 16;
 			files = (
-				7DE0978F1AC757AE0099D99C /* LlamaKit.framework in Copy Frameworks */,
+				D82399601B166EF00096E95C /* Box.framework in Copy Frameworks */,
+				D82399611B166EF00096E95C /* Result.framework in Copy Frameworks */,
 			);
 			name = "Copy Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -56,6 +62,18 @@
 			files = (
 			);
 			name = "Copy Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		D82399621B166F020096E95C /* Copy Files */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 16;
+			files = (
+				D82399631B166F0A0096E95C /* Box.framework in Copy Files */,
+				D82399641B166F0A0096E95C /* Result.framework in Copy Files */,
+			);
+			name = "Copy Files";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -78,8 +96,10 @@
 		7D44C4B619C8C9D70063E49F /* IncrementTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IncrementTests.swift; sourceTree = "<group>"; };
 		7D50B45F19D35F6200743806 /* CommandLineOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandLineOptions.swift; sourceTree = "<group>"; };
 		7D50B46119D35F9E00743806 /* CommandLineOptionsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CommandLineOptionsTests.swift; sourceTree = "<group>"; };
-		7DABE4091AC7706600D0017B /* LlamaKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LlamaKit.framework; path = Carthage/Build/Mac/LlamaKit.framework; sourceTree = "<group>"; };
-		7DE0978B1AC7546E0099D99C /* LlamaKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LlamaKit.framework; path = Carthage/Build/iOS/LlamaKit.framework; sourceTree = "<group>"; };
+		D82399561B166E5F0096E95C /* Box.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Box.framework; path = Carthage/Build/iOS/Box.framework; sourceTree = "<group>"; };
+		D82399571B166E5F0096E95C /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Build/iOS/Result.framework; sourceTree = "<group>"; };
+		D823995A1B166E7D0096E95C /* Box.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Box.framework; path = Carthage/Build/Mac/Box.framework; sourceTree = "<group>"; };
+		D823995B1B166E7D0096E95C /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Build/Mac/Result.framework; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,7 +107,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7DABE40A1AC7706600D0017B /* LlamaKit.framework in Frameworks */,
+				D82399581B166E5F0096E95C /* Box.framework in Frameworks */,
+				D82399591B166E5F0096E95C /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -95,7 +116,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				7DE0978D1AC756720099D99C /* LlamaKit.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -103,6 +123,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D823995C1B166E7D0096E95C /* Box.framework in Frameworks */,
+				D823995D1B166E7D0096E95C /* Result.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -119,8 +141,7 @@
 		7D3A7C2319C7631600346D07 = {
 			isa = PBXGroup;
 			children = (
-				7DABE4091AC7706600D0017B /* LlamaKit.framework */,
-				7DE097911AC7585E0099D99C /* iOS Frameworks */,
+				D823995F1B166EC40096E95C /* Frameworks */,
 				7D44C4A719C8C6420063E49F /* Common */,
 				7D44C4B419C8C9550063E49F /* CommonTests */,
 				7D3A7C2F19C7631700346D07 /* SemverKit */,
@@ -229,12 +250,31 @@
 			path = CommonTests;
 			sourceTree = "<group>";
 		};
-		7DE097911AC7585E0099D99C /* iOS Frameworks */ = {
+		7DE097911AC7585E0099D99C /* iOS */ = {
 			isa = PBXGroup;
 			children = (
-				7DE0978B1AC7546E0099D99C /* LlamaKit.framework */,
+				D82399561B166E5F0096E95C /* Box.framework */,
+				D82399571B166E5F0096E95C /* Result.framework */,
 			);
-			name = "iOS Frameworks";
+			name = iOS;
+			sourceTree = "<group>";
+		};
+		D823995E1B166EB80096E95C /* OSX */ = {
+			isa = PBXGroup;
+			children = (
+				D823995A1B166E7D0096E95C /* Box.framework */,
+				D823995B1B166E7D0096E95C /* Result.framework */,
+			);
+			name = OSX;
+			sourceTree = "<group>";
+		};
+		D823995F1B166EC40096E95C /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				D823995E1B166EB80096E95C /* OSX */,
+				7DE097911AC7585E0099D99C /* iOS */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -322,6 +362,7 @@
 				7D3A7C5D19C873BE00346D07 /* Sources */,
 				7D3A7C5E19C873BE00346D07 /* Frameworks */,
 				7D3A7C5F19C873BE00346D07 /* Resources */,
+				D82399621B166F020096E95C /* Copy Files */,
 			);
 			buildRules = (
 			);


### PR DESCRIPTION
Now that LlamaKit is defunct and things like RAC have switched over to Result.

This also fixes the OSX tests since they weren't copying the framework dependencies to a path that the loader could find them.
